### PR TITLE
Fixed wired package reference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ dataclasses
 venusian
 pytest
 coverage
-git+https://github.com/pauleveritt/wired.git@dataclasses#egg=wired
+git+https://github.com/pauleveritt/wired.git


### PR DESCRIPTION
Before this change, the pip install of requirements failed because
dataclasses branch/tag doesn't currently exist @ https://github.com/pauleveritt/wired.git

After this change, the pip install successfully completes and installs the files in the
wired repo.  Maybe more than needed.

Tested on a venv in Ubuntu 19.10, Python version 3.7.5

> ❯ .venv/bin/pip install -r requirements.txt                                                                                                                                   ─╯
Obtaining file:///home/riley/PycharmProjects/42-workshop (from -r requirements.txt (line 1))
Collecting dataclasses (from -r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/26/2f/1095cdc2868052dd1e64520f7c0d5c8c550ad297e944e641dbf1ffbb9a5d/dataclasses-0.6-py3-none-any.whl
Collecting venusian (from -r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/43/92/3d522a710867168ee422a0ffbd712c425ece937aaeec4381497a59e24faf/venusian-3.0.0-py3-none-any.whl
Collecting pytest (from -r requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/93/16/f6dec5178f5f4141e80dfc4812a9aba88f5f29ca881f174ab1851181d016/pytest-5.2.2-py3-none-any.whl
Collecting coverage (from -r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/82/8f/a2a687fa00059360858023c5cb74e94b8afaf318726e9a256934066a9d90/coverage-4.5.4-cp37-cp37m-manylinux1_x86_64.whl
Collecting wired from git+https://github.com/pauleveritt/wired.git@dataclasses#egg=wired (from -r requirements.txt (line 6))
  Cloning https://github.com/pauleveritt/wired.git (to revision dataclasses) to /tmp/pip-install-xy9m9491/wired
  Did not find branch or tag 'dataclasses', assuming revision or ref.
error: pathspec 'dataclasses' did not match any file(s) known to git
Command "git checkout -q dataclasses" failed with error code 1 in /tmp/pip-install-xy9m9491/wired